### PR TITLE
temp fix for mutable actions

### DIFF
--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -20,7 +20,11 @@ import {EventBusService} from './shared/event-bus.service';
     ],
     imports: [
         BrowserModule,
-        StoreModule.forRoot(reducers),
+        StoreModule.forRoot(reducers, {
+            runtimeChecks: {
+                strictActionImmutability: false
+            }
+        }),
         EffectsModule.forRoot([AppEventBusEffects]),
         !environment.production ? StoreDevtoolsModule.instrument({maxAge: 25}) : []
     ],


### PR DESCRIPTION
This pull request provides a temporary fix for the issue of mutable actions. It turned out that the current client app fails with the following error:

```
core.js:6006 ERROR TypeError: Cannot add property publishedByUser, object is not extensible
    at AppEventBusService.publishAction (app.event-bus.service.ts:96)
    at TapSubscriber._tapNext (app.event-bus.effects.ts:22)
    at TapSubscriber._next (tap.js:40)
    at TapSubscriber.next (Subscriber.js:49)
    at FilterSubscriber._next (filter.js:33)
    at FilterSubscriber.next (Subscriber.js:49)
    at ScannedActionsSubject.next (Subject.js:39)
    at SafeSubscriber._next (ngrx-store-devtools.js:1467)
    at SafeSubscriber.__tryOrUnsub (Subscriber.js:183)
    at SafeSubscriber.next (Subscriber.js:122)
```

It happens in the following method, in the line where the `action.publishedByUser` is set.

```
    publishAction(action: RemoteAction) {
        if (!this.enabled) {
            return;
        }
        if (action.publishedByUser) {
            console.error('This action has already been published', action);
            return;
        }
        action.publishedByUser = this.currentUser;
        this.eventBusService.publish(action.eventBusAddress, action);
    }
```

The following code does not pass `strictActionImmutability` check, which is enabled by default.  This temporal fix disables this runtime check, but at some point of time, we should consider refactoring the code to use only immutable actions as the documentation suggests:

https://ngrx.io/guide/store/configuration/runtime-checks